### PR TITLE
bind minios function virt_to_mfn

### DIFF
--- a/lib/bindings/mm_stubs.c
+++ b/lib/bindings/mm_stubs.c
@@ -15,6 +15,8 @@
  */
 
 #include <caml/mlvalues.h>
+#include <caml/alloc.h>
+#include <caml/memory.h>
 #include <mini-os/mm.h>
 
 CAMLprim value
@@ -27,4 +29,16 @@ CAMLprim value
 stub_heap_get_pages_used(value unit) // noalloc
 {
   return Val_long(minios_heap_pages_used);
+}
+
+/* expose the virt_to_mfn macro for converting a "virtual address number"
+ * (AKA "a pointer") to a machine frame number
+*/
+CAMLprim value
+stub_virt_to_mfn(value page)
+{
+  CAMLparam1(page);
+  CAMLlocal1(result);
+  result = caml_copy_nativeint(virt_to_mfn(Nativeint_val(page)));
+  CAMLreturn(result);
 }

--- a/lib/oS.mli
+++ b/lib/oS.mli
@@ -208,3 +208,16 @@ module Start_info : sig
   (** [xenstore_start_page ()] is the xenstore page automatically
       allocated by Xen. *)
 end
+
+module Xen : sig
+  (** Some more Xen-specific that is neither part of scheduling
+      nor startup info, and not tied to xenstore either. *)
+
+  val virt_to_mfn : nativeint -> nativeint
+  (** Convert a Xen virtual addr ["va"] to [MFN]
+    - This is a binding to Xen mini-os [virt_to_mfn()];
+    - The inverse function in minios is [__mfn_to_virt].
+    - example use: [OS.MM.virt_to_mfn (Io_page.get_addr your_io_page_t)]
+    - see https://xenbits.xen.org/docs/xtf/mm_8h_source.html
+      and https://wiki.xenproject.org/wiki/XenTerminology *)
+end

--- a/lib/oS.mlpack
+++ b/lib/oS.mlpack
@@ -9,3 +9,4 @@ Start_info
 Time
 Xenctrl
 Xs
+Xen

--- a/lib/xen.ml
+++ b/lib/xen.ml
@@ -1,0 +1,1 @@
+external virt_to_mfn : nativeint -> nativeint = "stub_virt_to_mfn"


### PR DESCRIPTION
This is currently needed for speaking to Qubes GUId, suspect it could be useful for other applications dealing with RPC between Xen domU too.

ping @hannesm who complained this wasn't upstreamed :)