### PR TITLE
Add grant-handling code to OS.Xen

### DIFF
--- a/bindings/gnttab_stubs.c
+++ b/bindings/gnttab_stubs.c
@@ -16,6 +16,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+/* Note: these stubs are currently used by both OS.Xen and xen-gnt's Gnt module.
+   Once xen-gnt stops using them, they can be cleaned up and unused ones removed.
+ */
+
 #include <mini-os/os.h>
 #include <mini-os/mm.h>
 #include <mini-os/gnttab.h>
@@ -45,21 +49,22 @@ extern grant_entry_t *gnttab_table;
 CAMLprim value stub_gnttab_interface_open(value unit)
 {
 	CAMLparam1(unit);
-	CAMLlocal1(result);
-	if (!map) {
-		/* FIXME: this should be done inside mini-os kernel.c */
-		map = (struct gntmap*) malloc(sizeof(struct gntmap));
-		gntmap_init(map);
-		printk("initialised mini-os gntmap\n");
-	}
-	result = Val_unit;
-	CAMLreturn(result);
+	CAMLreturn(Val_unit);
 }
 
 CAMLprim value stub_gnttab_interface_close(value unit)
 {
 	CAMLparam1(unit);
 	CAMLreturn(Val_unit);
+}
+
+void gnttab_init(void)
+{
+	init_gnttab();
+	/* FIXME: this should be done inside mini-os kernel.c */
+	map = (struct gntmap*) malloc(sizeof(struct gntmap));
+	gntmap_init(map);
+	printk("initialised mini-os gntmap\n");
 }
 
 CAMLprim value stub_gnttab_allocates(void)
@@ -234,6 +239,14 @@ stub_gntshr_end_access(value v_ref)
     gnttab_end_access(ref);
 
     return Val_unit;
+}
+
+CAMLprim value
+stub_gntshr_try_end_access(value v_ref)
+{
+    CAMLparam1(v_ref);
+    grant_ref_t ref = Int_val(v_ref);
+    CAMLreturn(Val_bool(gnttab_end_access(ref)));
 }
 
 CAMLprim value stub_gntshr_share_pages_batched(value xgh, value domid, value count, value writable) {

--- a/bindings/main.c
+++ b/bindings/main.c
@@ -26,6 +26,8 @@
 #include <caml/memory.h>
 #include <caml/callback.h>
 
+extern void gnttab_init(void);
+
 void _exit(int);
 int errno;
 static char *argv[] = { "mirage", NULL };
@@ -83,7 +85,7 @@ void start_kernel(void)
   init_console();
 
   /* Init grant tables. */
-  init_gnttab();
+  gnttab_init();
 
   /* Call our main function directly, without using Mini-OS threads. */
   app_main_thread(NULL);

--- a/lib/dune
+++ b/lib/dune
@@ -2,4 +2,4 @@
  (name oS)
  (public_name mirage-xen)
  (wrapped true)
- (libraries lwt cstruct xen-evtchn xen-gnt xenstore.client shared-memory-ring-lwt mirage-profile logs io-page-xen))
+ (libraries lwt cstruct xen-evtchn xen-gnt xenstore.client shared-memory-ring-lwt mirage-profile logs io-page-xen fmt))

--- a/lib/oS.mli
+++ b/lib/oS.mli
@@ -1,3 +1,20 @@
+(*
+ * Copyright (c) 2010 Anil Madhavapeddy <anil@recoil.org>
+ * Copyright (C) 2012-2014 Citrix Inc
+ * 
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 module Lifecycle : sig
 
 val await_shutdown_request :
@@ -209,4 +226,188 @@ module Xen : sig
     - example use: [OS.MM.virt_to_mfn (Io_page.get_addr your_io_page_t)]
     - see https://xenbits.xen.org/docs/xtf/mm_8h_source.html
       and https://wiki.xenproject.org/wiki/XenTerminology *)
+
+  (** {2 Grants} *)
+
+  (** Allow a local xen domain to read/write memory exported ("granted")
+      from foreign domains. Safe memory sharing is a building block of all
+      xen inter-domain communication protocols such as those for virtual
+      network and disk devices.
+
+      Foreign domains will explicitly "grant" us access to certain memory
+      regions such as disk buffers. These regions are uniquely identified
+      by the pair of (foreign domain id, integer reference) which is
+      passed to us over some existing channel (typically via xenstore keys
+      or via structures in previously-shared memory region). *)
+
+  module Gntref : sig
+    type t
+    (** Type of a grant table index (an integer), called a grant reference in
+        Xen's terminology. *)
+
+    val of_string : string -> (t, [> `Msg of string]) result
+    (** [of_string x] parses [x] as a 32-bit unsigned decimal. *)
+
+    val to_string : t -> string
+    (** [to_string x] is [x] formatted as a 32-bit unsigned decimal. *)
+
+    val pp : t Fmt.t
+
+    val to_int32 : t -> Int32.t
+    val of_int32 : Int32.t -> t
+  end
+
+  (** {2 Receiving foreign pages} *)
+
+  module Import : sig
+    type t = {
+      domid: int;
+      (** foreign domain who is exporting memory *)
+      ref: Gntref.t;
+      (** id which identifies the specific export in the foreign domain *)
+    }
+    (** A foreign domain must explicitly "grant" us memory and send us the
+        "reference". The pair of (foreign domain id, reference) uniquely
+        identifies the block of memory. This pair ("grant") is transmitted
+        to us out-of-band, usually either via xenstore during device setup or
+        via a shared memory ring structure. *)
+
+    module Local_mapping : sig
+      type t
+      (** Abstract type representing a locally-mapped shared memory page *)
+
+      val to_buf: t -> Io_page.t
+
+      val unmap_exn: t -> unit
+      (** Unmap a single mapping (which may involve multiple grants). Throws a
+          Failure if unsuccessful. *)
+
+      val unmap: t -> (unit, [> `Msg of string]) result
+      (** As above, but returning a [result] type. *)
+    end
+
+    val map_exn : t -> writable:bool -> Local_mapping.t
+    (** [map_exn grant ~writable] creates a single mapping from
+        [grant] that will be writable if [writable] is [true]. *)
+
+    val map : t -> writable:bool -> (Local_mapping.t, [> `Msg of string]) result
+    (** Like the above but wraps the result in a [result] type instead of
+        raising an exception. *)
+
+    val mapv_exn : t list -> writable:bool -> Local_mapping.t
+    (** [mapv_exn grants ~writable] creates a single contiguous
+        mapping from a list of grants that will be writable if
+        [writable] is [true]. Note the grant list can involve grants
+        from multiple domains. If the mapping fails (because at least
+        one grant fails to be mapped), then all grants are unmapped. *)
+
+    val mapv: t list -> writable:bool -> (Local_mapping.t, [> `Msg of string]) result
+    (** Like the above but wraps the result in a [result] type instead of
+        raising an exception. *)
+
+    val with_mapping : t -> writable:bool ->
+      (Local_mapping.t -> 'a Lwt.t) -> ('a, [> `Msg of string]) result Lwt.t
+    (** [with_mapping grant ~writable f] maps [grant], calls [f] on
+        the result, and then unmaps it. Returns [Error _] if the [map]
+        operation fails. *)
+  end
+
+  (** {2 Offering pages to foreign domains} *)
+
+  module Export : sig
+    type t
+    (** When sharing a number of pages with another domain, we receive back both the
+        list of grant references shared and actually mapped page(s). The foreign
+        domain can map the same shared memory, after being notified (e.g. via xenstore)
+        of our domid and list of references. *)
+
+    val refs : t -> Gntref.t list
+    (** The grant references that have been shared with the foreign domain. *)
+
+    val mapping : t -> Io_page.t
+    (** Mapping of the shared memory. *)
+
+    val share_pages : domid:int -> count:int -> writable:bool -> (t, [> `Grant_table_full]) result
+    (** [share_pages ~domid ~count ~writable] shares [count] pages with foreign
+        domain [domid]. [writable] determines whether or not the foreign domain
+        can write to the shared memory. You must not allow the returned share
+        to be GC'd before successfully calling [unshare] on it (if you do, the
+        memory and grant ref will be leaked). *)
+
+    val share_pages_exn : domid:int -> count:int -> writable:bool -> t
+    (* Like [share_pages], but raise an exception on error. *)
+
+    val try_unshare : release_refs:bool -> t -> (unit, [> `Busy]) result
+    (** [try_unshare ~release_refs t] unshares a single mapping (which may
+        involve multiple grants). If [release_refs = true] then it also calls
+        [put] on each grant. If it encounters a grant that is still in use then
+        it stops and returns [Error `Busy], with [t] containing the remaining grants.
+        In this case, you must call [try_unshare] again later to retry. *)
+
+    val unshare : release_refs:bool -> t -> unit Lwt.t
+    (** Like [try_unshare], but keeps trying until all pages have been unshared. *)
+
+    (** {2 Low-level interface} *)
+
+    val get : unit -> Gntref.t Lwt.t
+    (** Allocate a single grant table index *)
+
+    val get_n : int -> Gntref.t list Lwt.t
+    (** Allocate a block of n grant table indices *)
+
+    val put : Gntref.t -> unit
+    (** Deallocate a grant table index. *)
+
+    val get_nonblock : unit-> Gntref.t option
+    (** [get_nonblock ()] is [Some idx] if the grant table is not full,
+        or [None] otherwise. *)
+
+    val get_n_nonblock : int -> Gntref.t list
+    (** [get_n_nonblock count] is a list of grant table indices of
+        length [count], or [[]] if there if the table is too full to
+        accomodate [count] new grant references. *)
+
+    val num_free_grants : unit -> int
+    (** [num_free_grants ()] returns the number of instantaneously free grant
+        table indices *)
+
+    val with_ref : (Gntref.t -> 'a Lwt.t) -> 'a Lwt.t
+    (** [with_ref f] allocates a grant with [get], passes it to [f], and then [put]s it. *)
+
+    val with_refs : int -> (Gntref.t list -> 'a Lwt.t) -> 'a Lwt.t
+
+    val grant_access : domid:int -> writable:bool -> Gntref.t -> Io_page.t -> unit
+    (** [grant_access ~domid ~writable gntref page] adds a grant table
+        entry at index [gntref] to the grant table, granting access to
+        [domid] to read [page], and write to is as well if [writable] is
+        [true]. You must call [end_access] later to unshare the page. *)
+
+    val try_end_access : release_ref:bool -> Gntref.t -> (unit, [> `Busy]) result
+    (** [try_end_access gntref] removes entry index [gntref] from the grant
+        table. If [release_ref = true] then it also calls [put gntref] on
+        success. If the remote domain is still using the grant then it returns
+        [Error `Busy] instead. *)
+
+    val end_access : release_ref:bool -> Gntref.t -> unit Lwt.t
+    (** Like [try_end_access], but if the remote domain is still using the
+        grant then it sleeps for 10 seconds and tries again, until it succeeds.*)
+
+    val with_grant : domid:int -> writable:bool -> Gntref.t ->
+      Io_page.t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+    (** [with_grant ~domid ~writable gntref page f] shares access to [page] with [domid],
+        calls [f ()] and then unshares the page. *)
+
+    val with_grants : domid:int -> writable:bool -> Gntref.t list ->
+      Io_page.t list -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+  end
+
+  val console : Gntref.t
+  (** In xen-4.2 and later, the domain builder will allocate one of the
+      reserved grant table entries and use it to pre-authorise the console
+      backend domain. *)
+
+  val xenstore : Gntref.t
+  (** In xen-4.2 and later, the domain builder will allocate one of the
+      reserved grant table entries and use it to pre-authorise the xenstore
+      backend domain. *)
 end

--- a/lib/sched.ml
+++ b/lib/sched.ml
@@ -35,12 +35,10 @@ let suspend () =
   >>= fun xs_client ->
   Xs.suspend xs_client
   >>= fun () ->
-  Gnt.suspend ();
 
   let result = _suspend () in
 
   Generation.resume ();
-  Gnt.resume ();
   Activations.resume ();
   Xs.resume xs_client
   >>= fun () ->

--- a/lib/xen.ml
+++ b/lib/xen.ml
@@ -1,1 +1,232 @@
+(*
+ * Copyright (c) 2010 Anil Madhavapeddy <anil@recoil.org>
+ * Copyright (C) 2012-2014 Citrix Inc
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
 external virt_to_mfn : nativeint -> nativeint = "stub_virt_to_mfn"
+
+open Lwt
+
+module Gntref = struct
+  type t = int
+  (* Possibly this should be [Int32.t], like in vchan. But it's really a table index, so it won't overflow. *)
+
+  let of_string x =
+    match Int32.of_string ("0u" ^ x) with
+    | i32 when i32 >= 0l -> Ok (Int32.to_int i32)
+    | i32 -> Ok (Int32.to_int i32 + 1 lsl 32)   (* Note: this will only work on 64-bit platforms *)
+    | exception _ ->
+      Error (`Msg (Printf.sprintf "Invalid grant ref: %S is not a valid 32-bit unsigned integer" x))
+
+  let to_string t = Printf.sprintf "%u" t
+  let pp f t = Format.fprintf f "%u" t
+
+  let to_int32 = Int32.of_int
+  let of_int32 = Int32.to_int
+end
+
+type domid = int
+
+let console = 0 (* public/grant_table.h:GNTTAB_RESERVED_CONSOLE *)
+let xenstore = 1 (* public/grant_table.h:GNTTAB_RESERVED_XENSTORE *)
+
+let ten_seconds_in_ns = 10000000000L
+
+type grant_handle (* handle to a mapped grant *)
+
+let src = Logs.Src.create "gnt" ~doc:"Xen memory grants"
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Import = struct
+  type t = {
+    domid: domid;
+    ref: Gntref.t;
+  }
+
+  module Local_mapping = struct
+    type t = {
+      hs : grant_handle list;
+      pages: Io_page.t;
+    }
+
+    let make hs pages = { hs; pages }
+
+    let to_buf t = t.pages
+
+    external unmap_exn : unit -> grant_handle -> unit = "stub_gnttab_unmap"
+    let unmap_exn mapping = List.iter (unmap_exn ()) mapping.hs
+
+    let unmap mapping =
+      try Ok (unmap_exn mapping)
+      with ex -> Error (`Msg (Printexc.to_string ex))
+  end
+
+  external map_fresh_exn: unit -> Gntref.t -> domid -> bool -> (grant_handle * Io_page.t) = "stub_gnttab_map_fresh"
+
+  let map_exn grant ~writable =
+    let h, page = map_fresh_exn () grant.ref grant.domid writable in
+    Local_mapping.make [h] page
+
+  let map grant ~writable = try Ok (map_exn grant ~writable) with ex -> Error (`Msg (Printexc.to_string ex))
+
+  (* We must use a special mapv function to ensure the memory is mapped contiguously. *)
+  external mapv_batched_exn: unit -> int array -> bool -> (grant_handle * Io_page.t) = "stub_gnttab_mapv_batched"
+
+  let mapv_exn grants ~writable =
+    let count = List.length grants in
+    let grant_array = Array.make (count * 2) 0 in
+    List.iteri (fun i g ->
+        grant_array.(i * 2 + 0) <- g.domid;
+        grant_array.(i * 2 + 1) <- g.ref;
+      ) grants;
+    let h, page = mapv_batched_exn () grant_array writable in
+    Local_mapping.make [h] page
+
+  let mapv gs ~writable = try Ok (mapv_exn gs ~writable) with ex -> Error (`Msg (Printexc.to_string ex))
+
+  let with_mapping grant ~writable fn =
+    match map grant ~writable with
+    | Error _ as e -> Lwt.return e
+    | Ok mapping ->
+      Lwt.finalize
+        (fun () -> fn mapping >|= fun x -> Ok x)
+        (fun () -> Local_mapping.unmap_exn mapping; Lwt.return_unit)
+end
+
+module Export = struct
+  type t = {
+    mutable refs: Gntref.t list;
+    mapping: Io_page.t;
+  }
+
+  let refs t = t.refs
+  let mapping t = t.mapping
+
+  let put = Gnt.Gntshr.put
+  let num_free_grants = Gnt.Gntshr.num_free_grants
+  let get = Gnt.Gntshr.get
+
+  let get_n num =
+    let rec gen_gnts num acc =
+      match num with
+      | 0 -> return acc
+      | n ->
+        begin
+          get ()
+          >>= fun gnt ->
+          gen_gnts (n-1) (gnt :: acc)
+        end
+    in gen_gnts num []
+
+  let get_nonblock = Gnt.Gntshr.get_nonblock
+
+  let get_n_nonblock = Gnt.Gntshr.get_n_nonblock
+
+  let with_ref f =
+    get ()
+    >>= fun gnt ->
+    Lwt.finalize
+      (fun () -> f gnt)
+      (fun () -> Lwt.return (put gnt))
+
+  let with_refs n f =
+    get_n n
+    >>= fun gnts ->
+    Lwt.finalize
+      (fun () -> f gnts)
+      (fun () -> Lwt.return (List.iter put gnts))
+
+  external nr_entries : unit -> int = "stub_gnttab_nr_entries"
+
+  (* Any page that another domain can access MUST be in this array.
+     Otherwise, it could get GC'd and reused for something else. *)
+  let exports : Io_page.t option array = Array.make (nr_entries ()) None
+
+  external grant_access : Gntref.t -> Io_page.t -> int -> bool -> unit = "stub_gntshr_grant_access"
+
+  let grant_access ~domid ~writable gntref page =
+    MProf.Trace.label "Gntshr.grant_access";
+    if exports.(gntref) <> None then
+      Fmt.invalid_arg "Grant %a is already in use!" Gntref.pp gntref;
+    exports.(gntref) <- Some page;
+    try
+      grant_access gntref page domid writable
+    with ex ->
+      exports.(gntref) <- None;
+      raise ex
+
+  (* true if access has been ended, false if page is still being used (access has not changed) *)
+  external try_end_access : Gntref.t -> bool = "stub_gntshr_try_end_access"
+
+  let try_end_access ~release_ref g =
+    MProf.Trace.label "Gntshr.end_access";
+    if try_end_access g then (
+      exports.(g) <- None;
+      if release_ref then put g;
+      Ok ()
+    ) else (
+      Log.info (fun f -> f "Attempt to release grant %d, which is still mapped by the remote domain." g);
+      Error `Busy
+    )
+
+  let rec try_unshare ~release_refs t =
+    match t.refs with
+    | [] -> Ok ()
+    | g :: gs ->
+      match try_end_access ~release_ref:release_refs g with
+      | Error _ as e -> e
+      | Ok () ->
+        t.refs <- gs;
+        try_unshare ~release_refs t
+
+  let rec end_access ~release_ref g =
+    match try_end_access ~release_ref g with
+    | Ok () -> Lwt.return_unit
+    | Error `Busy ->
+      Time.sleep_ns ten_seconds_in_ns >>= fun () ->
+      end_access ~release_ref g
+
+  let rec unshare ~release_refs t =
+    match try_unshare ~release_refs t with
+    | Ok () -> Lwt.return_unit
+    | Error `Busy ->
+      Time.sleep_ns ten_seconds_in_ns >>= fun () ->
+      unshare ~release_refs t
+
+  let share_pages ~domid ~count ~writable =
+    (* First allocate a list of n pages. *)
+    let block = Io_page.get count in
+    let pages = Io_page.to_pages block in
+    match get_n_nonblock count with
+    | [] -> Error `Grant_table_full
+    | gntrefs ->
+      List.iter2 (grant_access ~domid ~writable) gntrefs pages;
+      Ok { refs = gntrefs; mapping = block }
+
+  let share_pages_exn ~domid ~count ~writable =
+    match share_pages ~domid ~count ~writable with
+    | Ok t -> t
+    | Error `Grant_table_full -> failwith "Grant table full"
+
+  let with_grant ~domid ~writable gnt page fn =
+    grant_access ~domid ~writable gnt page;
+    Lwt.finalize fn
+      (fun () -> end_access ~release_ref:false gnt)
+
+  let with_grants ~domid ~writable gnts pages fn =
+    List.iter2 (grant_access ~domid ~writable) gnts pages;
+    Lwt.finalize fn
+      (fun () -> Lwt_list.iter_s (end_access ~release_ref:false) gnts)
+end

--- a/mirage-xen.opam
+++ b/mirage-xen.opam
@@ -27,6 +27,7 @@ depends: [
   "io-page-xen" {>= "2.0.0"}
   "mirage-xen-minios" {>= "0.7.0"}
   "logs"
+  "fmt"
 ]
 available: [ os = "linux" ]
 synopsis: "Xen core platform libraries for MirageOS"


### PR DESCRIPTION
The [xen-gnt](https://github.com/mirage/ocaml-gnt) library provides a single OCaml module that tries to provide grant handling on Unix (for Unix domains running under the Xen hypervisor) and Xen (for unikernels using Mini-OS). However, these
platforms are really quite different: many of the functions provided in the xen-gnt API will raise an exception if called on the wrong platform, and many of the implementations call a C function to find out which platform is being used and then choose one of two implementations based on that. It is not possible to depend on Unix or Xen specific libraries in xen-gnt because a single implementation must work on both. Instead, everything platform-specific happens in the C stubs. The Unix stubs are in the xen-gnt repository, while the Xen ones are in mirage-xen, making it very hard to change anything safely.

This commit adds a new Xen-unikernel-only implmentation and API. It is based on xen-gnt's Gnt API, but specialised to Xen and cleaned up:

- All Unix code has been removed.
- The unused `interface` arguments have gone. This was just `unit` on Xen. The grant table is now always initialised at boot. The open and close functions are no longer needed and have gone.
- C stubs that do nothing are no longer called (but they do remain, to avoid breaking xen-gnt, which still links against them).
- `share_pages` and `share_pages_exn` now use labelled arguments (they take two integers and a bool and the meanings are not obvious).
- All `writable` parameters are now labelled for clarity.
- Gntref is now a module with an abstract type `t`. There are functions to parse and print grant refs.
- Many functions now indicate errors by returning a `result` (and don't throw away the error message, as many did by returning `None` for any error).
- I renamed `Gnttab` and `Gntshr` to `Import` and `Export`. This is partly because I always forget which is which, and partly so we can export the main type as `t` without it sounding like it represents a table.
- `Gnttab.grant` is now `Import.t`.
- `Gntshr.share` is now `Export.t` and is abstract.
- To improve safety, we now keep a table of exported pages. Sharing a page first adds it to this table. Unsharing removes it from the table on success. This prevents pages from being GC'd and reused while another domain still has access to them (which could otherwise happen if the unikernel is buggy).
- Various unsharing functions now take a `release_refs` flag that releases the grant refs after unsharing the pages (otherwise, it's easy to forget).
- We no longer call `Gnt.suspend` and `Gnt.resume`. These both simply call back to C stubs in mirage-xen, neither of which does anything.
- Operations on local mappings (`unmap_exn` and `unmap`) are now inside the `Local_mapping` module.
- `with_mapping` no longer passes `None` to the user function if the mapping fails. It just returns the error directly.

We still depend on xen-gnt. This is needed because it keeps track of free grant table entries and we can't duplicate that here as long as any library is still using xen-gnt.

My intention is that the Unix-specific parts of xen-gnt can be moved out to xen-gnt-unix (which is currently just C stubs). The kernel-specific parts can be removed. The [ocaml-vchan](https://github.com/mirage/ocaml-vchan/blob/88fae7a91aa790cf207ac4793bf8729b07fdd69d/lib/s.ml#L39) library contains its own grant
abstraction (Unix, Xen, and an in-memory test backend) which I think makes more sense for high-level cross-platform grant usage.