### PR TITLE
Drop support for old ocaml-gnt package

### DIFF
--- a/bindings/gnttab_stubs.c
+++ b/bindings/gnttab_stubs.c
@@ -16,10 +16,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-/* Note: these stubs are currently used by both OS.Xen and xen-gnt's Gnt module.
-   Once xen-gnt stops using them, they can be cleaned up and unused ones removed.
- */
-
 #include <mini-os/os.h>
 #include <mini-os/mm.h>
 #include <mini-os/gnttab.h>
@@ -46,18 +42,6 @@ extern grant_entry_t *gnttab_table;
 #define XC_GNTTAB_BIGARRAY (CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_EXTERNAL)
 
 
-CAMLprim value stub_gnttab_interface_open(value unit)
-{
-	CAMLparam1(unit);
-	CAMLreturn(Val_unit);
-}
-
-CAMLprim value stub_gnttab_interface_close(value unit)
-{
-	CAMLparam1(unit);
-	CAMLreturn(Val_unit);
-}
-
 void gnttab_init(void)
 {
 	init_gnttab();
@@ -65,22 +49,6 @@ void gnttab_init(void)
 	map = (struct gntmap*) malloc(sizeof(struct gntmap));
 	gntmap_init(map);
 	printk("initialised mini-os gntmap\n");
-}
-
-CAMLprim value stub_gnttab_allocates(void)
-{
-	CAMLparam0();
-	/* The mini-os API is now the same as the userspace Linux one: it
-	   returns fresh granted pages rather than expecting us to pass in
-	   an existing heap page. FIXME: remove the 'map_onto' API completely */
-	CAMLreturn(Val_bool(1));
-}
-
-CAMLprim value stub_gntshr_allocates(void)
-{
-	CAMLparam0();
-	/* We still manage our grant references from the OCaml code */
-	CAMLreturn(Val_bool(0));
 }
 
 static void *
@@ -161,20 +129,6 @@ CAMLprim value stub_gnttab_mapv_batched(value xgh, value array, value writable)
     CAMLreturn(pair);
 }
 
-/* No longer needed: stop_kernel now handles this automatically. */
-CAMLprim value
-stub_gnttab_fini(value unit)
-{
-    return Val_unit;
-}
-
-/* No longer needed: start_kernel now handles this automatically. */
-CAMLprim value
-stub_gnttab_init(value unit)
-{
-    return Val_unit;
-}
-
 /* Return the number of reserved grant entries at the start */
 CAMLprim value
 stub_gnttab_reserved(value unit)
@@ -189,22 +143,6 @@ stub_gnttab_nr_entries(value unit)
 }
 
 /* Exporting (sharing) pages */
-
-CAMLprim value stub_gntshr_open(value unit)
-{
-	CAMLparam1(unit);
-	CAMLlocal1(result);
-	result = Val_unit;
-	CAMLreturn(result);
-}
-
-CAMLprim value stub_gntshr_close(value unit)
-{
-	CAMLparam1(unit);
-	CAMLlocal1(result);
-	result = Val_unit;
-	CAMLreturn(result);
-}
 
 /* FIXME: we should use the mini-OS functions directly for these */
 
@@ -230,48 +168,9 @@ stub_gntshr_grant_access(value v_ref, value v_iopage, value v_domid, value v_wri
 }
 
 CAMLprim value
-stub_gntshr_end_access(value v_ref)
-{
-    grant_ref_t ref = Int_val(v_ref);
-
-    /* TODO: how should we handle failures due to the grant still being
-       mapped in on the other side? */
-    gnttab_end_access(ref);
-
-    return Val_unit;
-}
-
-CAMLprim value
 stub_gntshr_try_end_access(value v_ref)
 {
     CAMLparam1(v_ref);
     grant_ref_t ref = Int_val(v_ref);
     CAMLreturn(Val_bool(gnttab_end_access(ref)));
 }
-
-CAMLprim value stub_gntshr_share_pages_batched(value xgh, value domid, value count, value writable) {
-    CAMLparam4(xgh, domid, count, writable);
-    /* The OCaml code will never call this because gnttab_allocates is false */
-    printk("FATAL ERROR: stub_gntshr_share_pages_batched called\n");
-    caml_failwith("stub_gntshr_share_pages_batched");
-    CAMLreturn(Val_unit);
-}
-
-CAMLprim value stub_gntshr_munmap_batched(value xgh, value share) {
-    CAMLparam2(xgh, share);
-    /* The OCaml code will never call this because gnttab_allocates is false */
-    printk("FATAL ERROR: stub_gntshr_munmap_batched called\n");
-    caml_failwith("stub_gntshr_munmap_batched");
-    CAMLreturn(Val_unit);
-}
-
-CAMLprim value
-stub_gnttab_map_onto(value i, value v_ref, value v_iopage, value v_domid, value v_writable)
-{
-    CAMLparam5(i, v_ref, v_iopage, v_domid, v_writable);
-    /* The OCaml code will never call this because gnttab_allocates is true */
-    printk("FATAL ERROR: stub_gnttab_map_onto called\n");
-    caml_failwith("stub_gnttab_map_onto");
-    CAMLreturn(Val_unit);
-}
-

--- a/lib/dune
+++ b/lib/dune
@@ -2,4 +2,4 @@
  (name oS)
  (public_name mirage-xen)
  (wrapped true)
- (libraries lwt cstruct xen-evtchn xen-gnt xenstore.client shared-memory-ring-lwt mirage-profile logs io-page-xen fmt))
+ (libraries lwt cstruct xen-evtchn xenstore.client shared-memory-ring-lwt mirage-profile logs io-page-xen fmt))

--- a/lib/xen.ml
+++ b/lib/xen.ml
@@ -114,14 +114,33 @@ module Export = struct
   let refs t = t.refs
   let mapping t = t.mapping
 
-  (* The functions in Gnt are now deprecated so that people use mirage-xen instead.
-     Once they've been removed completely we can move the functions here, remove this,
-     and conflict with older versions of xen-gnt. *)
-  [@@@ocaml.warning "-3"]
+  let free_list : Gntref.t Queue.t = Queue.create ()
+  let free_list_waiters = Lwt_dllist.create ()
 
-  let put = Gnt.Gntshr.put
-  let num_free_grants = Gnt.Gntshr.num_free_grants
-  let get = Gnt.Gntshr.get
+  let count_gntref = MProf.Counter.make ~name:"gntref"
+
+  let put_no_count r =
+    Queue.push r free_list;
+    match Lwt_dllist.take_opt_l free_list_waiters with
+    | None -> ()
+    | Some u -> Lwt.wakeup u ()
+
+  let put r =
+    MProf.Counter.increase count_gntref (-1);
+    put_no_count r
+
+  let num_free_grants () = Queue.length free_list
+
+  let rec get () =
+    match Queue.is_empty free_list with
+    | true ->
+      let th, u = MProf.Trace.named_task "Wait for free gnt" in
+      let node = Lwt_dllist.add_r u free_list_waiters  in
+      Lwt.on_cancel th (fun () -> Lwt_dllist.remove node);
+      th >>= fun () -> get ()
+    | false ->
+      MProf.Counter.increase count_gntref (1);
+      return (Queue.pop free_list)
 
   let get_n num =
     let rec gen_gnts num acc =
@@ -135,11 +154,18 @@ module Export = struct
         end
     in gen_gnts num []
 
-  let get_nonblock = Gnt.Gntshr.get_nonblock
+  let get_nonblock () =
+    try Some (Queue.pop free_list) with Queue.Empty -> None
 
-  let get_n_nonblock = Gnt.Gntshr.get_n_nonblock
-
-  [@@@ocaml.warning "+3"]
+  let get_n_nonblock num =
+    let rec aux acc num = match num with
+      | 0 -> List.rev acc
+      | n ->
+        (match get_nonblock () with
+         | Some p -> aux (p::acc) (n-1)
+         (* If we can't have enough, we push them back in the queue. *)
+         | None -> List.iter (fun gntref -> Queue.push gntref free_list) acc; [])
+    in aux [] num
 
   let with_ref f =
     get ()
@@ -236,4 +262,12 @@ module Export = struct
     List.iter2 (grant_access ~domid ~writable) gnts pages;
     Lwt.finalize fn
       (fun () -> Lwt_list.iter_s (end_access ~release_ref:false) gnts)
+
+  external nr_entries : unit -> int = "stub_gnttab_nr_entries"
+  external nr_reserved : unit -> int = "stub_gnttab_reserved"
+
+  let () =
+    for i = nr_reserved () to nr_entries () - 1 do
+      put_no_count i
+    done
 end

--- a/mirage-xen.opam
+++ b/mirage-xen.opam
@@ -20,7 +20,6 @@ depends: [
   "shared-memory-ring-lwt"
   "xenstore" {>= "1.2.5"}
   "xen-evtchn" {>= "0.9.9"}
-  "xen-gnt" {>= "2.0.0"}
   "conf-pkg-config"
   "lwt-dllist"
   "mirage-profile" {>= "0.3"}


### PR DESCRIPTION
This allows us to remove some unused C stubs and means that we are now free to update the C functions without having to keep them in sync with ocaml-gnt.

The list of free grant refs is now kept in this module (the new code is just copied from ocaml-gnt, with the tests for Unix removed).

Attempting to link a unikernel that uses ocaml-gnt will now fail with e.g.

```
undefined reference to `stub_gnttab_init'
```

This is intended, since we would otherwise have two modules trying to track the free grant IDs. ocaml-gnt has marked all of the Xen-specific functions as deprecated (https://github.com/mirage/ocaml-gnt/pull/36), so users should get a more useful error from the compiler before getting to this stage, unless they used only the part of the API shared with Unix.

We should probably make a new release of ocaml-gnt before merging this, to ensure that users see the deprecation message.