### PR TITLE
OS.MM.Heap: Return sizes in bytes rather than pages

### DIFF
--- a/lib/bindings/main.c
+++ b/lib/bindings/main.c
@@ -19,6 +19,8 @@
 #include "hypercall.h"
 #include "xen/hvm/params.h"
 
+#include <assert.h>
+#include <limits.h>
 #include <stdlib.h>
 
 #define CAML_NAME_SPACE
@@ -109,18 +111,21 @@ mirage_xen_get_xenstore_page(value v_unit)
 
 /* @@noalloc */
 CAMLprim value
-mirage_xen_heap_get_pages_total(value v_unit)
+mirage_xen_get_heap_total_bytes(value v_unit)
 {
-    return Val_long(solo5_heap_size / PAGE_SIZE);
+    assert(solo5_heap_size <= LONG_MAX);
+    return caml_copy_int64(solo5_heap_size);
 }
 
 extern size_t malloc_footprint(void);
 
 /* @@noalloc */
 CAMLprim value
-mirage_xen_heap_get_pages_used(value v_unit)
+mirage_xen_get_heap_allocated_bytes(value v_unit)
 {
-    return Val_long(malloc_footprint() / PAGE_SIZE);
+    size_t allocated_bytes = malloc_footprint();
+    assert(allocated_bytes <= LONG_MAX);
+    return caml_copy_int64(allocated_bytes);
 }
 
 extern void _nolibc_init(uintptr_t, size_t);

--- a/lib/mM.ml
+++ b/lib/mM.ml
@@ -1,4 +1,7 @@
-module Heap_pages = struct
-  external total: unit -> int = "mirage_xen_heap_get_pages_total" [@@noalloc]
-  external used: unit -> int = "mirage_xen_heap_get_pages_used" [@@noalloc]
+module Heap = struct
+  external total_bytes: unit -> int64 =
+      "mirage_xen_get_heap_total_bytes" [@@noalloc]
+
+  external allocated_bytes: unit -> int64 =
+      "mirage_xen_get_heap_allocated_bytes" [@@noalloc]
 end

--- a/lib/oS.mli
+++ b/lib/oS.mli
@@ -35,11 +35,23 @@ val run : unit Lwt.t -> unit
 end
 
 module MM : sig
-module Heap_pages : sig
-  val total: unit -> int
-  val used: unit -> int
+
+(** Memory management operations. *)
+
+module Heap : sig
+  (** malloc() heap statistics. *)
+
+  val total_bytes: unit -> int64
+  (** [total_bytes] returns the total size of the heap, in bytes. *)
+
+  val allocated_bytes: unit -> int64
+  (** [allocated_bytes] returns the amount of memory allocated on the heap, in
+   * bytes. This call is cheap, but may return a value that is not 100% up to
+   * date. *)
+
 end
 end
+
 module Time : sig
 
 (** Timeout operations. *)


### PR DESCRIPTION
Replace the `OS.MM.Heap_pages` module with an `OS.MM.Heap` module that returns sizes in bytes, rather than pages which are arch-specific and ill-defined.

The new Heap module signature is:

```
module Heap : sig
  val total_bytes: unit -> int64
  val allocated_bytes: unit -> int64
end
```

The C functions called by the above will both `assert()` if a value larger than `LONG_MAX` would be returned; this is unlikely to happen in our lifetime.

@talex5 @hannesm Any objections? The assertion is just me being pedantic, since I don't know of a truly overflow-free way to get a 64-bit `size_t` into OCaml. Note that qubes-mirage-firewall will need to be updated to use the new interface.

I will also update mirage-solo5 to add whichever interface we add to mirage-xen for this.