### PR TITLE
Sync supported OCaml versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ env:
         - OCAML_VERSION=4.11
         - OCAML_VERSION=4.10
         - OCAML_VERSION=4.09
+        - OCAML_VERSION=4.08

--- a/mirage-xen.opam
+++ b/mirage-xen.opam
@@ -13,7 +13,7 @@ build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6.0"}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}


### PR DESCRIPTION
CI and OPAM availability should match in terms of the OCaml versions
supported by any particular package; for the new Mirage/Xen, make that
OCaml 4.08 or greater.