### PR TITLE
add caml_get_wall_clock -- similar to caml_get_monotonic_time

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,2 @@
+version = 0.15.0
+disable = true

--- a/lib/bindings/clock_stubs.c
+++ b/lib/bindings/clock_stubs.c
@@ -40,3 +40,10 @@ caml_get_monotonic_time(value v_unit)
   CAMLparam1(v_unit);
   CAMLreturn(caml_copy_int64(solo5_clock_monotonic()));
 }
+
+CAMLprim value
+caml_get_wall_clock(value v_unit)
+{
+  CAMLparam1(v_unit);
+  CAMLreturn(caml_copy_int64(solo5_clock_wall()));
+}

--- a/lib/dune
+++ b/lib/dune
@@ -2,20 +2,24 @@
  (name oS)
  (public_name mirage-xen)
  (libraries lwt cstruct xenstore.client shared-memory-ring-lwt lwt-dllist
-            mirage-profile logs io-page fmt mirage-runtime bheap duration))
+   mirage-profile logs io-page fmt mirage-runtime bheap duration))
 
 (rule
- (deps (source_tree bindings))
+ (deps
+  (source_tree bindings))
  (targets libmirage-xen_bindings.a)
  (action
- (no-infer
-  (progn
-   (chdir bindings (run %{make}))
-   (copy bindings/libmirage-xen_bindings.a libmirage-xen_bindings.a)))))
+  (no-infer
+   (progn
+    (chdir
+     bindings
+     (run %{make}))
+    (copy bindings/libmirage-xen_bindings.a libmirage-xen_bindings.a)))))
 
 (include_subdirs unqualified)
 
 (install
  (section lib)
- (files (bindings/mirage-xen.pc as ../pkgconfig/mirage-xen.pc)
-   (libmirage-xen_bindings.a as libmirage-xen_bindings.a)))
+ (files
+  (bindings/mirage-xen.pc as ../pkgconfig/mirage-xen.pc)
+  (libmirage-xen_bindings.a as libmirage-xen_bindings.a)))


### PR DESCRIPTION
The motivation is to avoid lots of conversions in mirage-clock just to retrieve
the current wall clock time. This is one part to solve
https://github.com/mirage/mirage-clock/issues/23

The unix_gettimeofday is still useful for the OCaml runtime system - which uses
it to initialize its RNG (the alternative is it being initialized with 0s which
is obviously worse) - that's why that symbol is kept as well.