### PR TITLE
Don't require opam for the bindings compilation

### DIFF
--- a/lib/bindings/Makefile
+++ b/lib/bindings/Makefile
@@ -1,4 +1,6 @@
-PKG_CONFIG_PATH := $(shell opam config var prefix)/lib/pkgconfig
+ifneq (, $(shell command -v opam))
+	PKG_CONFIG_PATH ?= $(shell opam config var prefix)/lib/pkgconfig
+endif
 
 CC ?= cc
 FREESTANDING_CFLAGS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags ocaml-freestanding)

--- a/lib/bindings/Makefile
+++ b/lib/bindings/Makefile
@@ -1,5 +1,5 @@
 ifneq (, $(shell command -v opam))
-	PKG_CONFIG_PATH ?= $(shell opam config var prefix)/lib/pkgconfig
+	PKG_CONFIG_PATH ?= $(shell opam var prefix)/lib/pkgconfig
 endif
 
 CC ?= cc


### PR DESCRIPTION
If opam is not present just use the `PKG_CONFIG_PATH` specified in the environment.

This fix is required for nixpkgs where we already set the `PKG_CONFIG_PATH` correctly when setting up the environment for the builder and don't have `opam` in path.