### PR TITLE
bindings compilation

### DIFF
--- a/lib/bindings/Makefile
+++ b/lib/bindings/Makefile
@@ -2,7 +2,7 @@
 all: libmirage-xen_bindings.a
 
 CC=ocamlfind -toolchain solo5 ocamlopt
-CFLAGS=-ccopt "-I ./include/ -O2 -std=c99 -Wall -Werror -D__XEN_INTERFACE_VERSION__=__XEN_LATEST_INTERFACE_VERSION__"
+CFLAGS=-ccopt "-I ./include/ -O2 -std=c99 -Wall -D__XEN_INTERFACE_VERSION__=__XEN_LATEST_INTERFACE_VERSION__"
 OBJS=bmap.o clock_stubs.o evtchn.o gnttab.o main.o
 
 libmirage-xen_bindings.a: $(OBJS)

--- a/lib/bindings/Makefile
+++ b/lib/bindings/Makefile
@@ -2,7 +2,7 @@
 all: libmirage-xen_bindings.a
 
 CC=ocamlfind -toolchain solo5 ocamlopt
-CFLAGS=-cclib "-I ./include/"
+CFLAGS=-ccopt "-I ./include/ -O2 -std=c99 -Wall -Werror -D__XEN_INTERFACE_VERSION__=__XEN_LATEST_INTERFACE_VERSION__"
 OBJS=bmap.o clock_stubs.o evtchn.o gnttab.o main.o
 
 libmirage-xen_bindings.a: $(OBJS)


### PR DESCRIPTION
This PR fix https://github.com/mirage/mirage/issues/1299 and the compilation options are taken from https://github.com/mirage/mirage-xen/commit/9fe3875a10aa3efb58ee571b5b5d6a8aa7a3e5ec. It is needed to correctly set the value of `__XEN_INTERFACE_VERSION__` at compile time. This macro is widely used in the bindings/include/xen files to handle the definitions of various constant across the xen versions.