### PR TITLE
Keep track of allocation and release memory (faster than by calling mallinfo and more accurate than calling footprint)

### DIFF
--- a/lib/bindings/main.c
+++ b/lib/bindings/main.c
@@ -117,13 +117,37 @@ mirage_memory_get_heap_words(value v_unit)
     return Val_long(solo5_heap_size / sizeof(value));
 }
 
+/*
+ * defined in ocaml freestanding dlmalloc.i
+*/
 extern size_t malloc_footprint(void);
+extern size_t malloc_memory_usage(void);
+extern int malloc_trim(size_t pad);
 
 /*
  * Caller: OS.Memory, @@noalloc
  */
 CAMLprim value
 mirage_memory_get_live_words(value v_unit)
+{
+    struct mallinfo m = mallinfo();
+    return Val_long(m.uordblks / sizeof(value));
+}
+
+/*
+ * Caller: OS.Memory, @@noalloc
+ */
+CAMLprim value
+mirage_memory_get_fast_memory_usage_words(value v_unit)
+{
+    return Val_long(malloc_memory_usage() / sizeof(value));
+}
+
+/*
+ * Caller: OS.Memory, @@noalloc
+ */
+CAMLprim value
+mirage_memory_get_fast_live_words(value v_unit)
 {
     return Val_long(malloc_footprint() / sizeof(value));
 }
@@ -142,6 +166,15 @@ mirage_memory_get_stack_words(value v_unit)
 
     return Val_long((sp_at_start - (uintptr_t)&dummy + 0x100000)
             / sizeof(value));
+}
+
+/*
+ * Caller: OS.Memory, @@noalloc
+ */
+CAMLprim value
+mirage_trim_allocation(value v_unit)
+{
+    return Val_long(malloc_trim(0));
 }
 
 extern void _nolibc_init(uintptr_t, size_t);

--- a/lib/bindings/main.c
+++ b/lib/bindings/main.c
@@ -138,18 +138,9 @@ mirage_memory_get_live_words(value v_unit)
  * Caller: OS.Memory, @@noalloc
  */
 CAMLprim value
-mirage_memory_get_fast_memory_usage_words(value v_unit)
-{
-    return Val_long(malloc_memory_usage() / sizeof(value));
-}
-
-/*
- * Caller: OS.Memory, @@noalloc
- */
-CAMLprim value
 mirage_memory_get_fast_live_words(value v_unit)
 {
-    return Val_long(malloc_footprint() / sizeof(value));
+    return Val_long(malloc_memory_usage() / sizeof(value));
 }
 
 /*

--- a/lib/memory.ml
+++ b/lib/memory.ml
@@ -20,9 +20,6 @@ external get_heap_words : unit -> int = "mirage_memory_get_heap_words"
 external get_live_words : unit -> int = "mirage_memory_get_live_words"
   [@@noalloc]
 
-external get_fast_memory_usage_words: unit -> int = "mirage_memory_get_fast_memory_usage_words"
-  [@@noalloc]
-
 external get_fast_live_words: unit -> int = "mirage_memory_get_fast_live_words"
   [@@noalloc]
 
@@ -48,11 +45,5 @@ let stat () =
 let quick_stat () =
   let h = get_heap_words () in
   let l = get_fast_live_words () in
-  let s = get_stack_words () in
-  { heap_words = h; live_words = l; stack_words = s; free_words = h - l - s; }
-
-let memory_usage_stat () =
-  let h = get_heap_words () in
-  let l = get_fast_memory_usage_words () in
   let s = get_stack_words () in
   { heap_words = h; live_words = l; stack_words = s; free_words = h - l - s; }

--- a/lib/memory.ml
+++ b/lib/memory.ml
@@ -20,7 +20,16 @@ external get_heap_words : unit -> int = "mirage_memory_get_heap_words"
 external get_live_words : unit -> int = "mirage_memory_get_live_words"
   [@@noalloc]
 
+external get_fast_memory_usage_words: unit -> int = "mirage_memory_get_fast_memory_usage_words"
+  [@@noalloc]
+
+external get_fast_live_words: unit -> int = "mirage_memory_get_fast_live_words"
+  [@@noalloc]
+
 external get_stack_words : unit -> int = "mirage_memory_get_stack_words"
+  [@@noalloc]
+
+external trim: unit -> unit = "mirage_trim_allocation"
   [@@noalloc]
 
 type stat = {
@@ -30,8 +39,20 @@ type stat = {
   free_words : int;
 }
 
-let quick_stat () =
+let stat () =
   let h = get_heap_words () in
   let l = get_live_words () in
   let s = get_stack_words () in
   { heap_words = h; live_words = l; stack_words = s; free_words = h - l - s }
+
+let quick_stat () =
+  let h = get_heap_words () in
+  let l = get_fast_live_words () in
+  let s = get_stack_words () in
+  { heap_words = h; live_words = l; stack_words = s; free_words = h - l - s; }
+
+let memory_usage_stat () =
+  let h = get_heap_words () in
+  let l = get_fast_memory_usage_words () in
+  let s = get_stack_words () in
+  { heap_words = h; live_words = l; stack_words = s; free_words = h - l - s; }

--- a/lib/memory.ml
+++ b/lib/memory.ml
@@ -20,14 +20,13 @@ external get_heap_words : unit -> int = "mirage_memory_get_heap_words"
 external get_live_words : unit -> int = "mirage_memory_get_live_words"
   [@@noalloc]
 
-external get_fast_live_words: unit -> int = "mirage_memory_get_fast_live_words"
+external get_fast_live_words : unit -> int = "mirage_memory_get_fast_live_words"
   [@@noalloc]
 
 external get_stack_words : unit -> int = "mirage_memory_get_stack_words"
   [@@noalloc]
 
-external trim: unit -> unit = "mirage_trim_allocation"
-  [@@noalloc]
+external trim : unit -> unit = "mirage_trim_allocation" [@@noalloc]
 
 type stat = {
   heap_words : int;
@@ -46,4 +45,4 @@ let quick_stat () =
   let h = get_heap_words () in
   let l = get_fast_live_words () in
   let s = get_stack_words () in
-  { heap_words = h; live_words = l; stack_words = s; free_words = h - l - s; }
+  { heap_words = h; live_words = l; stack_words = s; free_words = h - l - s }

--- a/lib/xen_os.mli
+++ b/lib/xen_os.mli
@@ -47,18 +47,18 @@ module Memory : sig
   (** Memory allocation statistics. Units are the system word size, as used by
       the OCaml stdlib Gc module. *)
 
-  val stat: unit -> stat
-  (** [stat ()]  returns memory allocation statistics. This uses mallinfo
-      and walks over the entire heap. This call is slower than quick_stat. *)
+  val stat : unit -> stat
+  (** [stat ()] returns memory allocation statistics. This uses mallinfo and
+      walks over the entire heap. This call is slower than quick_stat. *)
 
   val quick_stat : unit -> stat
-  (** [quick_stat ()] returns memory allocation statistics. This call uses
-      a precomputed value. This call is cheaper than stat, but the returned
-      values may not be completely accurate. *)
+  (** [quick_stat ()] returns memory allocation statistics. This call uses a
+      precomputed value. This call is cheaper than stat, but the returned values
+      may not be completely accurate. *)
 
-  val trim: unit -> unit
-  (** [trim ()]  release free memory from the heap (may update the value
-      returned by quick_state) *)
+  val trim : unit -> unit
+  (** [trim ()] release free memory from the heap (may update the value returned
+      by quick_state) *)
 end
 
 module Time : sig

--- a/lib/xen_os.mli
+++ b/lib/xen_os.mli
@@ -48,19 +48,14 @@ module Memory : sig
       the OCaml stdlib Gc module. *)
 
   val stat: unit -> stat
-  (** [stat ()]  returns memory allocation statistics. This call is slower
-      than quick_stat, and the returned values are accurate. *)
+  (** [stat ()]  returns memory allocation statistics. This uses mallinfo
+      and walks over the entire heap. This call is slower than quick_stat. *)
 
   val quick_stat : unit -> stat
-  (** [quick_stat ()] returns memory allocation statistics. This call is
-      computationally cheap, but the returned values may not be completely
-      accurate. *)
+  (** [quick_stat ()] returns memory allocation statistics. This call uses
+      a precomputed value. This call is cheaper than stat, but the returned
+      values may not be completely accurate. *)
 
-  val memory_usage_stat: unit -> stat
-  (** [memory_usage_stat ()]  returns memory allocation statistics. This call is
-      computationally cheap, and the returned values (even not be completely
-      accurate) should be more precise thant quick_stat. *)
-  
   val trim: unit -> unit
   (** [trim ()]  release free memory from the heap (may update the value
       returned by quick_state) *)

--- a/lib/xen_os.mli
+++ b/lib/xen_os.mli
@@ -47,10 +47,23 @@ module Memory : sig
   (** Memory allocation statistics. Units are the system word size, as used by
       the OCaml stdlib Gc module. *)
 
+  val stat: unit -> stat
+  (** [stat ()]  returns memory allocation statistics. This call is slower
+      than quick_stat, and the returned values are accurate. *)
+
   val quick_stat : unit -> stat
   (** [quick_stat ()] returns memory allocation statistics. This call is
       computationally cheap, but the returned values may not be completely
       accurate. *)
+
+  val memory_usage_stat: unit -> stat
+  (** [memory_usage_stat ()]  returns memory allocation statistics. This call is
+      computationally cheap, and the returned values (even not be completely
+      accurate) should be more precise thant quick_stat. *)
+  
+  val trim: unit -> unit
+  (** [trim ()]  release free memory from the heap (may update the value
+      returned by quick_state) *)
 end
 
 module Time : sig


### PR DESCRIPTION
This PR is related to https://github.com/mirage/ocaml-solo5/pull/120, it doesn't change the API and just adds:
* `Xen_os.Memory.trim()`: this will try to reduce the heap boundary,  the memory can be acquired back later as usual
* `Xen_os.Memory.stat()`: this will return information on memory based on `mallinfo` (it's accurate but slow as it have to loop over the heap to count the used memory)
* `Xen_os.Memory.memory_usage()`: this will return information on memory based on a `malloc_memory_usage` added by the ocaml-solo5 PR (current tests show that it is as accurate as `stat` and as fast as with `quick_stat`)

I'm currently not sure that the names are the best choices but I tried to not break any usage by not changing `quick_stat`.