### PR TITLE
Add Xen_os.Memory.metrics, a metrics source.

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.21.0
+version = 0.24.1
 profile = conventional
 
 parse-docstrings = true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## v8.0.2 (2023-03-03)
+
+* Provide Memory.metrics, a metrics source. Remove Mm.metrics metrics source.
+  (#51 @hannesm)
+
 ## v8.0.1 (2022-10-19)
 
 * Improve performance and take the opportunity to resolve pending

--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,8 @@
  (name xen_os)
  (public_name mirage-xen)
  (libraries lwt cstruct xenstore.client shared-memory-ring-lwt lwt-dllist
-   mirage-profile logs io-page fmt mirage-runtime bheap duration)
+   mirage-profile logs io-page fmt mirage-runtime bheap duration metrics
+   metrics-lwt)
  (no_dynlink)
  (foreign_archives mirage-xen_bindings))
 

--- a/lib/memory.ml
+++ b/lib/memory.ml
@@ -54,12 +54,13 @@ let metrics ?(quick = true) ~tags () =
   let data () =
     let stat = stat () in
     Data.v
-      [ uint "memory heap words" stat.heap_words
-      ; uint "memory live words" stat.live_words
-      ; uint "memory stack words" stat.stack_words
-      ; uint "memory free words" stat.free_words ]
+      [
+        uint "memory heap words" stat.heap_words;
+        uint "memory live words" stat.live_words;
+        uint "memory stack words" stat.stack_words;
+        uint "memory free words" stat.free_words;
+      ]
   in
   Src.v ~doc ~tags ~data "memory"
 
-let () =
-  Metrics_lwt.periodically (metrics ~tags:Metrics.Tags.[] ())
+let () = Metrics_lwt.periodically (metrics ~tags:Metrics.Tags.[] ())

--- a/lib/memory.ml
+++ b/lib/memory.ml
@@ -46,3 +46,20 @@ let quick_stat () =
   let l = get_fast_live_words () in
   let s = get_stack_words () in
   { heap_words = h; live_words = l; stack_words = s; free_words = h - l - s }
+
+let metrics ?(quick = true) ~tags () =
+  let open Metrics in
+  let doc = "Memory counters" in
+  let stat = if quick then quick_stat else stat in
+  let data () =
+    let stat = stat () in
+    Data.v
+      [ uint "memory heap words" stat.heap_words
+      ; uint "memory live words" stat.live_words
+      ; uint "memory stack words" stat.stack_words
+      ; uint "memory free words" stat.free_words ]
+  in
+  Src.v ~doc ~tags ~data "memory"
+
+let () =
+  Metrics_lwt.periodically (metrics ~tags:Metrics.Tags.[] ())

--- a/lib/xen_os.mli
+++ b/lib/xen_os.mli
@@ -59,6 +59,12 @@ module Memory : sig
   val trim : unit -> unit
   (** [trim ()] release free memory from the heap (may update the value returned
       by {!quick_stat}) *)
+
+  val metrics : ?quick:bool -> tags:'a Metrics.Tags.t -> unit ->
+    ('a, unit -> Metrics.Data.t) Metrics.src
+  (** [metrics ~quick ~tags] is a metrics source calling {quick_stat} (unless
+      [quick] is set to [false]) or {stat}. By default, this metrics source is
+      registered with [Metrics_lwt.periodically] (with [quick] set to [true]. *)
 end
 
 module Time : sig

--- a/lib/xen_os.mli
+++ b/lib/xen_os.mli
@@ -60,7 +60,10 @@ module Memory : sig
   (** [trim ()] release free memory from the heap (may update the value returned
       by {!quick_stat}) *)
 
-  val metrics : ?quick:bool -> tags:'a Metrics.Tags.t -> unit ->
+  val metrics :
+    ?quick:bool ->
+    tags:'a Metrics.Tags.t ->
+    unit ->
     ('a, unit -> Metrics.Data.t) Metrics.src
   (** [metrics ~quick ~tags] is a metrics source calling {quick_stat} (unless
       [quick] is set to [false]) or {stat}. By default, this metrics source is

--- a/mirage-xen.opam
+++ b/mirage-xen.opam
@@ -27,6 +27,8 @@ depends: [
   "fmt" {>= "0.8.5"}
   "bheap" {>= "2.0.0"}
   "duration"
+  "metrics"
+  "metrics-lwt" {>= "0.2.0"}
 ]
 available: [
   (arch = "x86_64" ) &


### PR DESCRIPTION
Register it with Metrics_lwt.periodically.

see https://github.com/mirage/mirage-solo5/pull/94 https://github.com/roburio/dns-secondary/pull/2